### PR TITLE
Added European national gambling sites

### DIFF
--- a/gambling-hosts
+++ b/gambling-hosts
@@ -1,7 +1,7 @@
-# Gambling hosts
+# Title: Gambling hosts
 # https://www.reddit.com/r/GlobalOffensiveGamble/comments/3d5fmr/list_of_csgo_gambling_websites/
 # http://www.top100bookmakers.com/completelist.php
-# Updated July 17, 2016
+# Updated September 3, 2018
 
 127.0.0.1 crownbet.com.au
 127.0.0.1 crownbet.com
@@ -118,6 +118,8 @@
 127.0.0.1 artemisbet10.com
 127.0.0.1 asianbeta.com
 127.0.0.1 www.asianbeta.com
+127.0.0.1 atg.se
+127.0.0.1 www.atg.se
 127.0.0.1 axbet.com
 127.0.0.1 www.axbet.com
 127.0.0.1 bananajackpot.com
@@ -684,6 +686,8 @@
 127.0.0.1 daisybingo.com
 127.0.0.1 www.daisybingo.com
 127.0.0.1 dakotacasino.com
+127.0.0.1 dantoto.dk
+127.0.0.1 www.dantoto.dk
 127.0.0.1 dashbet.com
 127.0.0.1 www.dashbet.com
 127.0.0.1 desertnightscasino.co.uk
@@ -720,6 +724,8 @@
 127.0.0.1 www.eccobet.com
 127.0.0.1 ed3688.com
 127.0.0.1 www.ed3688.com
+127.0.0.1 eestiloto.ee
+127.0.0.1 eestiloto.ee
 127.0.0.1 efbet.com
 127.0.0.1 www.efbet.com
 127.0.0.1 egamingbets.com
@@ -772,6 +778,8 @@
 127.0.0.1 www.favbet.com
 127.0.0.1 favourit.com
 127.0.0.1 www.favourit.com
+127.0.0.1 fdj.fr
+127.0.0.1 www.fdj.fr
 127.0.0.1 flemingtonsportsbet.com.au
 127.0.0.1 www.flemingtonsportsbet.com.au
 127.0.0.1 fonbet.com
@@ -1129,6 +1137,8 @@
 127.0.0.1 www.nitrogensports.eu
 127.0.0.1 nordicbet.com
 127.0.0.1 www.nordicbet.com
+127.0.0.1 norsk-tipping.no
+127.0.0.1 www.norsk-tipping.no
 127.0.0.1 novibet.com
 127.0.0.1 www.novibet.com
 127.0.0.1 noxwin.com
@@ -1235,6 +1245,8 @@
 127.0.0.1 www.redmilebets.com
 127.0.0.1 redstarsports.eu
 127.0.0.1 www.redstarsports.eu
+127.0.0.1 rikstoto.no
+127.0.0.1 www.rikstoto.no
 127.0.0.1 rivalo.com
 127.0.0.1 www.rivalo.com
 127.0.0.1 roadbet.com
@@ -1276,6 +1288,8 @@
 127.0.0.1 www.setantabet.com
 127.0.0.1 sirbobet.com
 127.0.0.1 www.sirbobet.com
+127.0.0.1 sisal.it
+127.0.0.1 www.sisal.it
 127.0.0.1 sjbet.at
 127.0.0.1 www.sjbet.at
 127.0.0.1 skedina.com
@@ -1391,6 +1405,8 @@
 127.0.0.1 www.supersportsbook.com
 127.0.0.1 superusacasino.com
 127.0.0.1 www.superusacasino.com
+127.0.0.1 svenskaspel.se
+127.0.0.1 www.svenskaspel.se
 127.0.0.1 tab.co.nz
 127.0.0.1 www.tab.co.nz
 127.0.0.1 tab.com.au
@@ -1471,6 +1487,8 @@
 127.0.0.1 www.vandersports.com
 127.0.0.1 vbet.com
 127.0.0.1 www.vbet.com
+127.0.0.1 veikkaus.fi
+127.0.0.1 www.veikkaus.fi
 127.0.0.1 vernons.com
 127.0.0.1 www.vernons.com
 127.0.0.1 vestabet365.com


### PR DESCRIPTION
Having stumbled across your list, and seeing that *Danske Spil* (The national Danish lottery) was on this list, I decided to attempt to some other entries as well. Specifically the national lotteries of Norway, Sweden, Finland, Estonia, France and Italy, and the national horse betting companies of Norway, Sweden and Denmark.

I also hope you won't mind that I added `Title:` to the left of `Gambling hosts`. This makes it so that if anyone subscribes to this list with uBlock Origin, then it'll be shown in the users' settings as `Gambling hosts` instead of `https://raw.githubusercontent.com/Sinfonietta/hostfiles/master/gambling-hosts`. The same could technically be done for the other three lists as well.