### PR TITLE
Block locale-based Reddit hosts

### DIFF
--- a/social-hosts
+++ b/social-hosts
@@ -1247,3 +1247,4 @@
 127.0.0.1 amp-reddit-com.cdn.ampproject.org
 127.0.0.1 old.reddit.com
 127.0.0.1 new.reddit.com
+127.0.0.1 reddit.map.fastly.net


### PR DESCRIPTION
Reddit provides localized version of the website by prepending the URL with a locale like `de.reddit.com` or `de-at.reddit.com`. It would be quite inefficient to block all of the hosts according to the `[a-z]{2}(-[a-z]{2})?.reddit.com` pattern. But, all of this hosts get resolved to the CDN host `reddit.map.fastly.net`, which can be blocked. Example:

```
$ ping de-at.reddit.com
PING reddit.map.fastly.net (151.101.113.140) 56(84) bytes of data.
64 bytes from 151.101.113.140 (151.101.113.140): icmp_seq=1 ttl=57 time=30.9 ms
64 bytes from 151.101.113.140 (151.101.113.140): icmp_seq=2 ttl=57 time=30.5 ms
```

```
$ ping pt-br.reddit.com
PING reddit.map.fastly.net (151.101.113.140) 56(84) bytes of data.
64 bytes from 151.101.113.140 (151.101.113.140): icmp_seq=1 ttl=57 time=33.1 ms
64 bytes from 151.101.113.140 (151.101.113.140): icmp_seq=2 ttl=57 time=30.6 ms
```