### PR TITLE
Blocking mixtape.moe

### DIFF
--- a/snuff-hosts
+++ b/snuff-hosts
@@ -8,5 +8,6 @@
 127.0.0.1 goregrish.com
 127.0.0.1 theync.com
 127.0.0.1 miscopy.com
+127.0.0.1 mixtape.moe
 127.0.0.1 elblogdelnarco.com
 127.0.0.1 kaotic.com


### PR DESCRIPTION
This one is iffy. It's not dedicated to snuff, but it is used for hosting lots of it.