### PR TITLE
Added 3 entries for Denmark

### DIFF
--- a/pornography-hosts
+++ b/pornography-hosts
@@ -2955,6 +2955,7 @@
 127.0.0.1 ein.xxx
 127.0.0.1 ejzbrokenangelz.com
 127.0.0.1 www.ejzbrokenangelz.com
+127.0.0.1 ekstrabladet.dk
 127.0.0.1 elangelito.com
 127.0.0.1 www.elangelito.com
 127.0.0.1 eldervagina.com
@@ -3036,6 +3037,7 @@
 127.0.0.1 erodynamics.nl
 127.0.0.1 www.erodynamics.nl
 127.0.0.1 eroluv.com
+127.0.0.1 eromaxxx.dk
 127.0.0.1 erome.com
 127.0.0.1 www.erome.com
 127.0.0.1 www.erooups.com
@@ -8552,6 +8554,7 @@
 127.0.0.1 sicflics.com
 127.0.0.1 www.sicflics.com
 127.0.0.1 sid-vd.ru
+127.0.0.1 side6.dk
 127.0.0.1 sihteeriopisto.co
 127.0.0.1 silkangels.com
 127.0.0.1 www.silkangels.com


### PR DESCRIPTION
I've been heavily questioning in the past years if `Ekstrabladet` even counted as a newspaper anymore, since sometimes as many as half of its articles were about supermodels taking off their clothes. Currently it's like 10~15% due to various COVID-related breaking news taking their usual spots, but still.

So I did some research, and found `https://ekstrabladet.dk/sex_og_samliv/`, which has quite a few articles about BDSM, PornHub videos, porn awards, poster girls, porn parties, etc. I also found they were even facilitating sex services at `https://ekstrabladet.dk/massageescort/`.

The `Mest læste i Kendte` section at the bottom of `https://ekstrabladet.dk/plus/kendte/` also has various stories about bottom-tier celebs allegedly taking off their clothes, sex stories, and bottom-tier celebs making porn.

I have therefore concluded that it's a porn site. I also added entries for two fulltime-erotic sister sites it seems to have.