### PR TITLE
Update snuff-hosts

### DIFF
--- a/snuff-hosts
+++ b/snuff-hosts
@@ -12,6 +12,7 @@
 127.0.0.1 theync.com
 127.0.0.1 miscopy.com
 127.0.0.1 mixtape.moe
+127.0.0.1 recipepes.com
 127.0.0.1 sickjunk.com
 127.0.0.1 elblogdelnarco.com
 127.0.0.1 kaotic.com


### PR DESCRIPTION
I'm unsure if the site deliberately hosts snuff or not. At first it appears to be a food recipes site, but there is a lower section in search results of website labeled "receipes from other sites" -- that's where you'll find the snuff.

Here is an example (you will have to reverse the percent encoding to get the working link). Too horrifying to post directly.
https%3A%2F%2Frecipepes.com%2Findx.html%3Futm_content%3Dmexican%2Bcartel%2Bskinned%2Balive

Interesting side note is that the email address posted in the footer of this website (https://web.archive.org/web/20210502094750if_/https://recipepes.com/images/whois.png) comes up in this wikileaks entry (https://wikileaks.org/akp-emails/emailid/363788). Something to do with Turkey.

I recommend blocking it.