### PR TITLE
Specify subdomain where ads/trackers come from

### DIFF
--- a/pornography-hosts
+++ b/pornography-hosts
@@ -2171,7 +2171,6 @@
 0.0.0.0 camsloveaholics.com
 0.0.0.0 camslurp.com
 0.0.0.0 camsluts.icu
-0.0.0.0 camsoda.com
 0.0.0.0 camsplus.xyz
 0.0.0.0 camster.com
 0.0.0.0 camstube.org
@@ -8146,6 +8145,7 @@
 0.0.0.0 parispornmovies.com
 0.0.0.0 partie-privee.com
 0.0.0.0 partners.adultadworld.com
+0.0.0.0 partners.camsoda.com
 0.0.0.0 party-cams.com
 0.0.0.0 party.jerkoffgalleries.com
 0.0.0.0 partysexs.com


### PR DESCRIPTION
Specify the domain within camsoda.com where the ads and trackers are hosted.