### PR TITLE
Add devilpain dot com to snuff hosts

### DIFF
--- a/snuff-hosts
+++ b/snuff-hosts
@@ -20,3 +20,4 @@
 127.0.0.1 ogrish.tv
 127.0.0.1 thepinsta.com
 127.0.0.1 vidmax.com
+127.0.0.1 devilpain.com


### PR DESCRIPTION
It's basically a porn site, but has some pretty disgusting stuff, too. There are categories for scat and snuff/necro porn which I didn't dare click on yet as the start page looks pretty gruesome and disgusting already. Therefore I propose to add this domain to the snuff list. 