### PR TITLE
Add gambling and porn domains

### DIFF
--- a/gambling-hosts
+++ b/gambling-hosts
@@ -277,6 +277,7 @@
 0.0.0.0 bingoyard.com
 0.0.0.0 bitcoinsports.eu
 0.0.0.0 bitsaloon.com
+0.0.0.0 blancoshrimp.com
 0.0.0.0 blog.maxbet.rs
 0.0.0.0 bobcasino.com
 0.0.0.0 bobetting.com
@@ -1622,6 +1623,7 @@
 0.0.0.0 www.bitcoinrush.io
 0.0.0.0 www.bitcoinsports.eu
 0.0.0.0 www.bitsaloon.com
+0.0.0.0 www.blancoshrimp.com
 0.0.0.0 www.bobcasino.com
 0.0.0.0 www.bobetting.com
 0.0.0.0 www.bobregister.com

--- a/gambling-hosts
+++ b/gambling-hosts
@@ -3,7 +3,7 @@
 # <https://raw.githubusercontent.com/lassekongo83/Frellwits-filter-lists/master/anti-casino-and-betting-hosts-file.txt>
 # <https://www.reddit.com/r/GlobalOffensiveGamble/comments/3d5fmr/list_of_csgo_gambling_websites/>
 # Title: Gambling hosts
-# Updated Jun 22, 2022
+# Updated March 12, 2023
 0.0.0.0 10bet.com
 0.0.0.0 10luxury39.com
 0.0.0.0 11wickets.com

--- a/pornography-hosts
+++ b/pornography-hosts
@@ -4167,6 +4167,7 @@
 0.0.0.0 fineartteens.com
 0.0.0.0 finegayporn.com
 0.0.0.0 finehairypussy.com
+0.0.0.0 finehookupclubs.com
 0.0.0.0 finemomtube.com
 0.0.0.0 fineporn.xxx
 0.0.0.0 finestcartoonporn.com


### PR DESCRIPTION
These domains open automatically when watching videos on mmacore.tv:

- blancoshrimp.com: gambling.
- finehookupclubs.com: porn, example hXXps[:]//finehookupclubs[.]com/l/25/shagslags/3b-w3mr/global/