### PR TITLE
🐛 remove non-domain entries

### DIFF
--- a/pornography-hosts
+++ b/pornography-hosts
@@ -25706,7 +25706,7 @@
 0.0.0.0 fuq.bdsmsite.net
 0.0.0.0 fuq5.com
 0.0.0.0 fuqtubes.com
-0.0.0.0 ga.poebushki.com/pussy-fucking
+0.0.0.0 ga.poebushki.com
 0.0.0.0 gamesofdesired.com
 0.0.0.0 garotosafado.net
 0.0.0.0 gay-xvideos.net
@@ -26836,7 +26836,7 @@
 0.0.0.0 www.xvideos.skin
 0.0.0.0 www.xvideosyoutube.com
 0.0.0.0 www.xvideoz.charity
-0.0.0.0 www.xvideoz.lifehttps://
+0.0.0.0 www.xvideoz.life
 0.0.0.0 www.xvxx.me
 0.0.0.0 www.xxnxx.monster
 0.0.0.0 www.xxnxx.tattoo


### PR DESCRIPTION
This PR removes 2 non-domain entries:
```
  [i] Target: https://raw.githubusercontent.com/Sinfonietta/hostfiles/master/pornography-hosts
  [✓] Status: Retrieval successful
  [✓] Parsed 27570 exact domains and 0 ABP-style domains (ignored 2 non-domain entries)
      Sample of non-domain entries:
        - "ga.poebushki.com/pussy-fucking"
        - "www.xvideoz.lifehttps://"
```

@Sinfonietta , please check if my PR is what it should have been by removing only some "strange" parts so we now get a domain entry instead!