### PR TITLE
Remove false-positives from pornography-hosts

### DIFF
--- a/pornography-hosts
+++ b/pornography-hosts
@@ -27130,8 +27130,6 @@
 0.0.0.0 www.porngen.art
 0.0.0.0 x-pictures.io
 0.0.0.0 penly.ai
-0.0.0.0 top.gg
-0.0.0.0 lexica.art
 0.0.0.0 pornai.tv
 0.0.0.0 onlyfakes.app
 0.0.0.0 www.pornlabs.net
@@ -27169,7 +27167,6 @@
 0.0.0.0 heatedaffairs.com
 0.0.0.0 www.sugardaddymeet.com
 0.0.0.0 www.mysugardaddy.com
-0.0.0.0 www.go3fun.co
 0.0.0.0 hello.transsexdates.com
 0.0.0.0 fetlife.com
 0.0.0.0 hello.asiansingles.me
@@ -27177,7 +27174,6 @@
 0.0.0.0 www.bicupid.com
 0.0.0.0 www.tmb5trk.com
 0.0.0.0 undertable.co
-0.0.0.0 tinder.com
 0.0.0.0 www.naughtyamericavr.com
 0.0.0.0 virtualtaboo.com
 0.0.0.0 www.czechvr.com
@@ -27373,13 +27369,10 @@
 0.0.0.0 www.yaoiotaku.com
 0.0.0.0 www.mangago.me
 0.0.0.0 www.yaoihavenreborn.com
-0.0.0.0 www.mangahome.com
-0.0.0.0 mangahasu.se
 0.0.0.0 www.simply-hentai.com
 0.0.0.0 fuhouse.club
 0.0.0.0 www.erofus.com
 0.0.0.0 baramangaonline.com
-0.0.0.0 fanfox.net
 0.0.0.0 nhentaiyaoi.net
 0.0.0.0 www.classcomics.com
 0.0.0.0 rent.men
@@ -27403,7 +27396,6 @@
 0.0.0.0 www.gaypornstarharem.com
 0.0.0.0 www.3dgayvilla.com
 0.0.0.0 www.guyselector.com
-0.0.0.0 www.comdotgame.com
 0.0.0.0 gay.gameporntube.com
 0.0.0.0 gayeti.gumroad.com
 0.0.0.0 pridedrawing.itch.io
@@ -27523,7 +27515,6 @@
 0.0.0.0 gayconnect.com
 0.0.0.0 www.321sexchat.com
 0.0.0.0 www.squirt.org
-0.0.0.0 secure.cmvrclicks000.com
 0.0.0.0 www.adam4adam.com
 0.0.0.0 www.manhunt.net
 0.0.0.0 www.queermenow.net
@@ -27531,7 +27522,6 @@
 0.0.0.0 www.queerclick.com
 0.0.0.0 www.thesword.com
 0.0.0.0 www.manhuntdaily.com
-0.0.0.0 thegailygrind.com
 0.0.0.0 gaybodyblog.com
 0.0.0.0 www.gayheaven.org
 0.0.0.0 justusboys.com


### PR DESCRIPTION
Remove some false-positives added in #277, sorry about that.

* Dating apps
  * `tinder.com`
  * `www.go3fun.co`
* Manga websites
  * `fanfox.net`
  * `mangahasu.se`
  * `www.mangahome.com`
* AI image generation
  * `lexica.art`
* Etc.
  * `www.comdotgame.com` - flash games
  * `secure.cmvrclicks000.com` - redirect tracker, not relevant and already blocked in StevenBlack/hosts
  * `thegailygrind.com` - LGBTQ+ news website
  * `top.gg` - Discord bots and servers search