### PR TITLE
Removed mixxx.org

### DIFF
--- a/pornography-hosts
+++ b/pornography-hosts
@@ -47401,7 +47401,6 @@
 0.0.0.0 exxxn.com
 0.0.0.0 hd-xxx.cc
 0.0.0.0 lporn.org
-0.0.0.0 mixxx.org
 0.0.0.0 momxxx.cc
 0.0.0.0 mporn.org
 0.0.0.0 okporn.cc


### PR DESCRIPTION
Removed https://mixxx.org from the pornography-hosts file, as it was added by accident in [this commit](https://github.com/Sinfonietta/hostfiles/commit/edea60d1c3753a1b59a588b69866f9c01bb7e100)

