### PR TITLE
🚸 add spiegel.com because it's NOT the english version of german newspaper spiegel.de

### DIFF
--- a/pornography-hosts
+++ b/pornography-hosts
@@ -15798,6 +15798,7 @@
 0.0.0.0 spicytranny.com
 0.0.0.0 spicytrannyhd.com
 0.0.0.0 spicyvintageporn.com
+0.0.0.0 spiegel.com
 0.0.0.0 spitzetitten.com
 0.0.0.0 spitzetitten.net
 0.0.0.0 spizoo-com.ru
@@ -22607,6 +22608,7 @@
 0.0.0.0 www.spermatube.be
 0.0.0.0 www.spicybigtits.com
 0.0.0.0 www.spicyporntrials.com
+0.0.0.0 www.spiegel.com
 0.0.0.0 www.spunkysheets.com
 0.0.0.0 www.squirtinglesbian.com
 0.0.0.0 www.squirtingorgies.com


### PR DESCRIPTION
The title says it all. Just have a look at it - how many people have gone there by accident because they mistyped `.de` or thought it would be the english version!? 😱