### PR TITLE
🚸 remove uproxx.com from porn because this is an American music, entertainment and popular culture website and content studio and not related to porn

### DIFF
--- a/pornography-hosts
+++ b/pornography-hosts
@@ -50120,7 +50120,6 @@
 0.0.0.0 www.uporno.xxx
 0.0.0.0 upornosite.com
 0.0.0.0 upox.com
-0.0.0.0 uproxx.com
 0.0.0.0 www.upshemaleporn.com
 0.0.0.0 upskirt.top
 0.0.0.0 upskirt.tv


### PR DESCRIPTION
My wife was complaining that she couldn't read this website 😆 See https://en.wikipedia.org/wiki/Uproxx for some more details.