### PR TITLE
Add missing instagram domain

### DIFF
--- a/social-hosts
+++ b/social-hosts
@@ -2167,6 +2167,7 @@
 127.0.0.1 z-p42-scontent-yyz1-1.cdninstagram.com
 127.0.0.1 z-p42-scontent.cdninstagram.com
 127.0.0.1 z-p42-static.cdninstagram.com
+127.0.0.1 scontent.fallback.cdninstagram.com
 
 # Whatsapp
 127.0.0.1 account.whatsapp.com


### PR DESCRIPTION
This pull request includes a small change to the `social-hosts` file. The change adds a new entry for `scontent.fallback.cdninstagram.com` to the list of social hosts.

* [`social-hosts`](diffhunk://#diff-b5f4472bb1ded074338427678f730bbef41b3dcc4c3c1b61bbcda9a91f4cf555R2170): Added `127.0.0.1 scontent.fallback.cdninstagram.com` to the list.